### PR TITLE
pc - rename all of the GitHub workflows to a more sensible naming convention

### DIFF
--- a/.github/workflows/00-publish-docs-to-github-pages-setup.yml
+++ b/.github/workflows/00-publish-docs-to-github-pages-setup.yml
@@ -1,5 +1,5 @@
 
-name: Publish 00 docs create repos
+name: "00-publish-docs-to-github-pages-setup: set up -docs and -docs-qa repos (run once, manually)"
 on: 
   workflow_dispatch:
 jobs:

--- a/.github/workflows/02-publish-docs-to-github-pages-qa.yml
+++ b/.github/workflows/02-publish-docs-to-github-pages-qa.yml
@@ -1,5 +1,6 @@
 
-name: 00 Publish 01 docs (Storybook) to GitHub Pages QA
+name: "02-publish-docs-to-github-pages-qa: Publish QA Storybook to GitHub Pages"
+
 on: 
   workflow_dispatch:
   pull_request:

--- a/.github/workflows/04-publish-docs-to-github-pages-prod.yml
+++ b/.github/workflows/04-publish-docs-to-github-pages-prod.yml
@@ -1,5 +1,5 @@
 
-name: 00 Publish 02 docs (Storybook) to GitHub Pages
+name: "04-publish-docs-to-github-pages-prod: Publish production Storybook to GitHub Pages"
 on: 
   workflow_dispatch:
   push:

--- a/.github/workflows/10-backend-unit.yml
+++ b/.github/workflows/10-backend-unit.yml
@@ -1,8 +1,7 @@
 # This workflow will build a Java project with Maven
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
 
-name: 01 Backend 03 Mutation Testing (Pitest)
-
+name: "10-backend-unit: Java Unit tests"
 on:
   workflow_dispatch:
   push:
@@ -12,10 +11,9 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
     timeout-minutes: 10
-
+    
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK 17
@@ -27,10 +25,4 @@ jobs:
       env:
         TEST_PROPERTIES: ${{ secrets.TEST_PROPERTIES }}
       run: mvn -B test 
-    - name: Pitest
-      run: mvn test org.pitest:pitest-maven:mutationCoverage
-    - name: Upload Pitest to Artifacts
-      uses: actions/upload-artifact@v2
-      with:
-        name: pitest-mutation-testing
-        path: target/pit-reports/* 
+   

--- a/.github/workflows/12-backend-jacoco.yml
+++ b/.github/workflows/12-backend-jacoco.yml
@@ -1,7 +1,7 @@
 # This workflow will build a Java project with Maven
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
 
-name: 01 Backend 01 Tests (JUnit)
+name: "12-backend-jacoco: Java Test Coverage (Jacoco)"
 
 on:
   workflow_dispatch:
@@ -12,9 +12,10 @@ on:
 
 jobs:
   build:
+
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    
+
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK 17
@@ -25,5 +26,8 @@ jobs:
     - name: Build with Maven
       env:
         TEST_PROPERTIES: ${{ secrets.TEST_PROPERTIES }}
-      run: mvn -B test 
-   
+      run: mvn -B test jacoco:report 
+    - name: Upload to Codecov
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      run: bash <(curl -s https://codecov.io/bash)

--- a/.github/workflows/14-backend-pitest.yml
+++ b/.github/workflows/14-backend-pitest.yml
@@ -1,7 +1,7 @@
 # This workflow will build a Java project with Maven
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
 
-name: 03 Check Production Build (if this fails, deploying to Heroku will fail)
+name: "12-backend-pitest: Java Mutation Testing (Pitest)"
 
 on:
   workflow_dispatch:
@@ -26,7 +26,11 @@ jobs:
     - name: Build with Maven
       env:
         TEST_PROPERTIES: ${{ secrets.TEST_PROPERTIES }}
-        PRODUCTION: true
-      run: mvn -DskipTests clean dependency:list install
-
-  
+      run: mvn -B test 
+    - name: Pitest
+      run: mvn test org.pitest:pitest-maven:mutationCoverage
+    - name: Upload Pitest to Artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: pitest-mutation-testing
+        path: target/pit-reports/* 

--- a/.github/workflows/30-frontend-tests.yml
+++ b/.github/workflows/30-frontend-tests.yml
@@ -1,4 +1,4 @@
-name: 02 Frontend 03 Mutation Testing (JavaScript/Stryker, testing the test suite)
+name: "30-frontend-tests: JavaScript, Jest Unit tests"
 
 on:
   workflow_dispatch:
@@ -10,7 +10,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 40
+    timeout-minutes: 10
 
     strategy:
       matrix:
@@ -25,5 +25,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: npm ci
         working-directory: ./frontend
-      - run: npx stryker run
+      - run: npm test
         working-directory: ./frontend
+    

--- a/.github/workflows/32-frontend-coverage.yml
+++ b/.github/workflows/32-frontend-coverage.yml
@@ -1,4 +1,4 @@
-name: 02 Frontend 02 Coverage (JavaScript/Jest)
+name: "32-frontend-coverage: Frontend Coverage (JavaScript/Jest)"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/34-frontend-mutation-testing.yml
+++ b/.github/workflows/34-frontend-mutation-testing.yml
@@ -1,4 +1,4 @@
-name: 02 Frontend 01 Tests (JavaScript/Jest)
+name: "34-frontend-mutation-testing: Stryker JS Mutation Testing (JavaScript/Jest)"
 
 on:
   workflow_dispatch:
@@ -10,7 +10,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 40
 
     strategy:
       matrix:
@@ -25,6 +25,5 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: npm ci
         working-directory: ./frontend
-      - run: npm test
+      - run: npx stryker run
         working-directory: ./frontend
-    

--- a/.github/workflows/40-check-production-build.yml
+++ b/.github/workflows/40-check-production-build.yml
@@ -1,7 +1,7 @@
 # This workflow will build a Java project with Maven
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
 
-name: 01 Backend 02 Coverage (Jacoco)
+name: "40-check-production-build: Check Production Build (if this fails, deploying to Heroku will fail)"
 
 on:
   workflow_dispatch:
@@ -26,8 +26,7 @@ jobs:
     - name: Build with Maven
       env:
         TEST_PROPERTIES: ${{ secrets.TEST_PROPERTIES }}
-      run: mvn -B test jacoco:report 
-    - name: Upload to Codecov
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      run: bash <(curl -s https://codecov.io/bash)
+        PRODUCTION: true
+      run: mvn -DskipTests clean dependency:list install
+
+  

--- a/.github/workflows/99-publish-clean-up-docs-qa.yml
+++ b/.github/workflows/99-publish-clean-up-docs-qa.yml
@@ -1,5 +1,5 @@
 
-name: 00 Publish 99 Clean up docs-qa
+name: "99-publish-clean-up-docs-qa: Run this to clean out old branches on QA Docs site"
 on: 
   workflow_dispatch:
 jobs:


### PR DESCRIPTION
# Overview

In this PR, we rename the workflow files, and update the `name` field in the `.yml` files under `.github/workflows` to be easier to follow.

Before:  Inconsistent naming:

```
00-publish-01-docs-to-github-pages-qa.yml
00-publish-02-docs-to-github-pages.yml
00-publish-99-clean-up-docs-qa.yml
01-backend-01-unit.yml
01-backend-02-jacoco.yml
01-backend-03-pitest.yml
02-frontend-01-tests.yml
02-frontend-02-coverage.yml
02-frontend-03-mutation-testing.yml
03-check-production-build.yml
publish-00-docs-to-github-pages-setup.yml
```




After:  Consistent naming

```
00-publish-docs-to-github-pages-setup.yml
02-publish-docs-to-github-pages-qa.yml
04-publish-docs-to-github-pages-prod.yml
10-backend-unit.yml
12-backend-jacoco.yml
14-backend-pitest.yml
30-frontend-tests.yml
32-frontend-coverage.yml
34-frontend-mutation-testing.yml
40-check-production-build.yml
99-publish-clean-up-docs-qa.yml
```

<img width="910" alt="image" src="https://user-images.githubusercontent.com/1119017/162288545-883a121f-55cc-4849-9904-70c9dbcd00f6.png">


