### PR TITLE
AL - Use latest Node 16 LTS in Heroku and GitHub Actions

### DIFF
--- a/.github/workflows/02-publish-docs-to-github-pages-qa.yml
+++ b/.github/workflows/02-publish-docs-to-github-pages-qa.yml
@@ -11,11 +11,18 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
+    strategy:
+      matrix:
+        node-version: [16.x]
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v2.3.1
         with:
           persist-credentials: false
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
       - name: Figure out Branch name
         run: | 
           GITHUB_HEAD_REF="${GITHUB_HEAD_REF}"

--- a/.github/workflows/04-publish-docs-to-github-pages-prod.yml
+++ b/.github/workflows/04-publish-docs-to-github-pages-prod.yml
@@ -10,11 +10,18 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
+    strategy:
+      matrix:
+        node-version: [16.x]
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v2.3.1
         with:
           persist-credentials: false
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
       - name: Append name of site to _config.yml
         working-directory: ./frontend/docs-index
         run: | 

--- a/.github/workflows/10-backend-unit.yml
+++ b/.github/workflows/10-backend-unit.yml
@@ -2,11 +2,11 @@
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
 
 name: "10-backend-unit: Java Unit tests"
+
 on:
   workflow_dispatch:
-  push:
-    branches: [ main ]
   pull_request:
+  push:
     branches: [ main ]
 
 jobs:

--- a/.github/workflows/12-backend-jacoco.yml
+++ b/.github/workflows/12-backend-jacoco.yml
@@ -5,14 +5,12 @@ name: "12-backend-jacoco: Java Test Coverage (Jacoco)"
 
 on:
   workflow_dispatch:
-  push:
-    branches: [ main ]
   pull_request:
+  push:
     branches: [ main ]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
     timeout-minutes: 10
 

--- a/.github/workflows/14-backend-pitest.yml
+++ b/.github/workflows/14-backend-pitest.yml
@@ -5,14 +5,12 @@ name: "12-backend-pitest: Java Mutation Testing (Pitest)"
 
 on:
   workflow_dispatch:
-  push:
-    branches: [ main ]
   pull_request:
+  push:
     branches: [ main ]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
     timeout-minutes: 10
 

--- a/.github/workflows/30-frontend-tests.yml
+++ b/.github/workflows/30-frontend-tests.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [17.x]
+        node-version: [16.x]
     steps:
       - uses: actions/checkout@v2
         with: 

--- a/.github/workflows/32-frontend-coverage.yml
+++ b/.github/workflows/32-frontend-coverage.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [17.x]
+        node-version: [16.x]
     steps:
       - uses: actions/checkout@v2
         with: 

--- a/.github/workflows/34-frontend-mutation-testing.yml
+++ b/.github/workflows/34-frontend-mutation-testing.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [17.x]
+        node-version: [16.x]
     steps:
       - uses: actions/checkout@v2
         with: 

--- a/pom.xml
+++ b/pom.xml
@@ -243,8 +243,7 @@
                                     <goal>install-node-and-npm</goal>
                                 </goals>
                                 <configuration>
-                                    <nodeVersion>v12.12.0</nodeVersion>
-                                    <npmVersion>6.14.3</npmVersion>
+                                    <nodeVersion>v16.14.2</nodeVersion>
                                 </configuration>
                             </execution>
                             <execution>


### PR DESCRIPTION
This PR makes a number of changes to establish consistency across development, CI, and production deployment environments.

Namely:
* GitHub Actions frontend test workflows use Node 16 (and bundled npm 8.5) instead of Node 17
* Heroku now builds the app with Node 16 (and bundled npm 8.5) instead of Node 12 and npm 6.14
* Storybook is now set to build with Node 16 (and bundled npm 8.5)

Also, as a quality-of-life change, backend Actions workflows can now run on any pull request, instead of just pull requests to the main branch