### PR TITLE
AL - Re-add ESLint and fix linting errors

### DIFF
--- a/.github/workflows/14-backend-pitest.yml
+++ b/.github/workflows/14-backend-pitest.yml
@@ -1,7 +1,7 @@
 # This workflow will build a Java project with Maven
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
 
-name: "12-backend-pitest: Java Mutation Testing (Pitest)"
+name: "14-backend-pitest: Java Mutation Testing (Pitest)"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/36-frontend-eslint.yml
+++ b/.github/workflows/36-frontend-eslint.yml
@@ -1,0 +1,27 @@
+name: "36-frontend-eslint: JavaScript style checking"
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    strategy:
+      matrix:
+        node-version: [16.x]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm ci
+        working-directory: ./frontend
+      - run: npx eslint --max-warnings 0 .
+        working-directory: ./frontend

--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -1,0 +1,31 @@
+{
+  "root": true,
+  "extends": ["react-app"],
+  "env": {
+    "browser": true
+  },
+  "overrides": [
+    {
+      "files": ["src/stories/**", "src/test/**/*.js"],
+      "rules": {
+        "import/no-anonymous-default-export": "off"
+      },
+      "env": {
+        "node": true,
+        "jest": true
+      }
+    }
+  ],
+  "rules": {
+    "no-unused-vars": [
+      "error",
+      {
+        "vars": "all",
+        "varsIgnorePattern": "^_",
+        "args": "all",
+        "argsIgnorePattern": "^_",
+        "ignoreRestSiblings": true
+      }
+    ]
+  }
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -42,6 +42,7 @@
         "@testing-library/react-hooks": "^5.1.2",
         "axios-mock-adapter": "^1.19.0",
         "env-cmd": "^10.1.0",
+        "eslint": "^8.14.0",
         "eslint-plugin-flowtype": "^8.0.3",
         "eslint-plugin-import": "^2.25.4",
         "eslint-plugin-react-hooks": "^4.2.1-rc.0-next-64223fed8-20220210",
@@ -2088,15 +2089,15 @@
       "dev": true
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.1.0.tgz",
-      "integrity": "sha512-C1DfL7XX4nPqGd6jcP01W9pVM1HYCuUkFk1432D7F0v3JSlUIeOYn9oCoi3eoLZ+iwBSb29BMFxxny0YrrEZqg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.2.tgz",
+      "integrity": "sha512-lTVWHs7O2hjBFZunXTZYnYqtB9GakA1lnxIf+gKq2nY5gxkkNi/lQvveW6t8gFdOHTg6nG50Xs95PrLqVpcaLg==",
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
         "espree": "^9.3.1",
         "globals": "^13.9.0",
-        "ignore": "^4.0.6",
+        "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
         "js-yaml": "^4.1.0",
         "minimatch": "^3.0.4",
@@ -2127,9 +2128,9 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "node_modules/@eslint/eslintrc/node_modules/globals": {
-      "version": "13.12.1",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.12.1.tgz",
-      "integrity": "sha512-317dFlgY2pdJZ9rspXDks7073GpDmXdfbM3vYYp0HAMKGDh1FfWPleI2ljVNLQX5M5lXcAslTcPTrOrMEFOjyw==",
+      "version": "13.13.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.13.0.tgz",
+      "integrity": "sha512-EQ7Q18AJlPwp3vUDL4mKA0KXrXyNIQyWon6T6XQiBQF0XHvRsiCSrWmmeATpUzdJN2HhWZU6Pdl0a9zdep5p6A==",
       "dependencies": {
         "type-fest": "^0.20.2"
       },
@@ -2138,14 +2139,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/ignore": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
-      "engines": {
-        "node": ">= 4"
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
@@ -12827,36 +12820,6 @@
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
       "integrity": "sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA=="
     },
-    "node_modules/babel-eslint": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.1.0.tgz",
-      "integrity": "sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==",
-      "deprecated": "babel-eslint is now @babel/eslint-parser. This package will no longer receive updates.",
-      "dev": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/parser": "^7.7.0",
-        "@babel/traverse": "^7.7.0",
-        "@babel/types": "^7.7.0",
-        "eslint-visitor-keys": "^1.0.0",
-        "resolve": "^1.12.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "peerDependencies": {
-        "eslint": ">= 4.12.1"
-      }
-    },
-    "node_modules/babel-eslint/node_modules/eslint-visitor-keys": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/babel-jest": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-27.5.1.tgz",
@@ -17257,11 +17220,11 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.9.0.tgz",
-      "integrity": "sha512-PB09IGwv4F4b0/atrbcMFboF/giawbBLVC7fyDamk5Wtey4Jh2K+rYaBhCAbUyEI4QzB1ly09Uglc9iCtFaG2Q==",
+      "version": "8.14.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.14.0.tgz",
+      "integrity": "sha512-3/CE4aJX7LNEiE3i6FeodHmI/38GZtWCsAtsymScmzYapx8q1nVVb+eLcLSzATmCPXw5pT4TqVs1E0OmxAd9tw==",
       "dependencies": {
-        "@eslint/eslintrc": "^1.1.0",
+        "@eslint/eslintrc": "^1.2.2",
         "@humanwhocodes/config-array": "^0.9.2",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
@@ -36284,15 +36247,15 @@
       "dev": true
     },
     "@eslint/eslintrc": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.1.0.tgz",
-      "integrity": "sha512-C1DfL7XX4nPqGd6jcP01W9pVM1HYCuUkFk1432D7F0v3JSlUIeOYn9oCoi3eoLZ+iwBSb29BMFxxny0YrrEZqg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.2.tgz",
+      "integrity": "sha512-lTVWHs7O2hjBFZunXTZYnYqtB9GakA1lnxIf+gKq2nY5gxkkNi/lQvveW6t8gFdOHTg6nG50Xs95PrLqVpcaLg==",
       "requires": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
         "espree": "^9.3.1",
         "globals": "^13.9.0",
-        "ignore": "^4.0.6",
+        "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
         "js-yaml": "^4.1.0",
         "minimatch": "^3.0.4",
@@ -36316,17 +36279,12 @@
           "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
         },
         "globals": {
-          "version": "13.12.1",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-13.12.1.tgz",
-          "integrity": "sha512-317dFlgY2pdJZ9rspXDks7073GpDmXdfbM3vYYp0HAMKGDh1FfWPleI2ljVNLQX5M5lXcAslTcPTrOrMEFOjyw==",
+          "version": "13.13.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-13.13.0.tgz",
+          "integrity": "sha512-EQ7Q18AJlPwp3vUDL4mKA0KXrXyNIQyWon6T6XQiBQF0XHvRsiCSrWmmeATpUzdJN2HhWZU6Pdl0a9zdep5p6A==",
           "requires": {
             "type-fest": "^0.20.2"
           }
-        },
-        "ignore": {
-          "version": "4.0.6",
-          "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-          "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
         },
         "js-yaml": {
           "version": "4.1.0",
@@ -44570,27 +44528,6 @@
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
       "integrity": "sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA=="
     },
-    "babel-eslint": {
-      "version": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.1.0.tgz",
-      "integrity": "sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==",
-      "dev": true,
-      "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/parser": "^7.7.0",
-        "@babel/traverse": "^7.7.0",
-        "@babel/types": "^7.7.0",
-        "eslint-visitor-keys": "^1.0.0",
-        "resolve": "^1.12.0"
-      },
-      "dependencies": {
-        "eslint-visitor-keys": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
-          "dev": true
-        }
-      }
-    },
     "babel-jest": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-27.5.1.tgz",
@@ -47988,11 +47925,11 @@
       }
     },
     "eslint": {
-      "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.9.0.tgz",
-      "integrity": "sha512-PB09IGwv4F4b0/atrbcMFboF/giawbBLVC7fyDamk5Wtey4Jh2K+rYaBhCAbUyEI4QzB1ly09Uglc9iCtFaG2Q==",
+      "version": "8.14.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.14.0.tgz",
+      "integrity": "sha512-3/CE4aJX7LNEiE3i6FeodHmI/38GZtWCsAtsymScmzYapx8q1nVVb+eLcLSzATmCPXw5pT4TqVs1E0OmxAd9tw==",
       "requires": {
-        "@eslint/eslintrc": "^1.1.0",
+        "@eslint/eslintrc": "^1.2.2",
         "@humanwhocodes/config-array": "^0.9.2",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -37,6 +37,7 @@
     "@testing-library/react-hooks": "^5.1.2",
     "axios-mock-adapter": "^1.19.0",
     "env-cmd": "^10.1.0",
+    "eslint": "^8.14.0",
     "eslint-plugin-flowtype": "^8.0.3",
     "eslint-plugin-import": "^2.25.4",
     "eslint-plugin-react-hooks": "^4.2.1-rc.0-next-64223fed8-20220210",
@@ -51,6 +52,12 @@
     "coverage": "react-scripts test --coverage --watchAll=false",
     "storybook": "start-storybook --docs -p 6006 -s public",
     "build-storybook": "build-storybook --docs -s public"
+  },
+  "eslintConfig": {
+    "extends": [
+      "react-app",
+      "react-app/jest"
+    ]
   },
   "browserslist": {
     "production": [

--- a/frontend/src/main/components/Students/StudentsTable.js
+++ b/frontend/src/main/components/Students/StudentsTable.js
@@ -1,4 +1,3 @@
-import { useMemo } from "react";
 import OurTable from "main/components/OurTable";
 
 export default function StudentsTable({ students }) {
@@ -21,11 +20,8 @@ export default function StudentsTable({ students }) {
         }
     ];
 
-    // Stryker disable next-line ArrayDeclaration : [students] is a performance optimization
-    const memoizedDates = useMemo(() => students, [students]);
-
     return <OurTable
-        data={memoizedDates}
+        data={students}
         columns={columns}
         testid={"StudentsTable"}
     />;

--- a/frontend/src/main/components/Students/StudentsTable.js
+++ b/frontend/src/main/components/Students/StudentsTable.js
@@ -1,8 +1,7 @@
-import React from "react";
+import { useMemo } from "react";
 import OurTable from "main/components/OurTable";
 
-export default function StudentsTable({ students, currentUser }) {
-
+export default function StudentsTable({ students }) {
     const columns = [
         {
             Header: 'id',
@@ -22,14 +21,12 @@ export default function StudentsTable({ students, currentUser }) {
         }
     ];
 
-    // Stryker disable ArrayDeclaration : [columns] and [students] are performance optimization; mutation preserves correctness
-    const memoizedColumns = React.useMemo(() => columns, [columns]);
-    const memoizedDates = React.useMemo(() => students, [students]);
-    // Stryker enable ArrayDeclaration
+    // Stryker disable next-line ArrayDeclaration : [students] is a performance optimization
+    const memoizedDates = useMemo(() => students, [students]);
 
     return <OurTable
         data={memoizedDates}
-        columns={memoizedColumns}
+        columns={columns}
         testid={"StudentsTable"}
     />;
 };

--- a/frontend/src/main/components/UCSBDates/UCSBDateForm.js
+++ b/frontend/src/main/components/UCSBDates/UCSBDateForm.js
@@ -1,8 +1,6 @@
-import React, {useState} from 'react'
 import { Button, Form } from 'react-bootstrap';
-import { useForm } from 'react-hook-form'
-import { useNavigate } from 'react-router-dom'
-
+import { useForm } from 'react-hook-form';
+import { useNavigate } from 'react-router-dom';
 
 function UCSBDateForm({ initialUCSBDate, submitAction, buttonLabel="Create" }) {
 

--- a/frontend/src/main/components/UCSBDates/UCSBDatesTable.js
+++ b/frontend/src/main/components/UCSBDates/UCSBDatesTable.js
@@ -1,6 +1,5 @@
-import React from "react";
+import { useMemo } from "react";
 import OurTable, { ButtonColumn } from "main/components/OurTable";
-// import { toast } from "react-toastify";
 import { useBackendMutation } from "main/utils/useBackend";
 import { cellToAxiosParamsDelete, onDeleteSuccess } from "main/utils/UCSBDateUtils"
 import { useNavigate } from "react-router-dom";
@@ -15,7 +14,6 @@ export default function UCSBDatesTable({ dates, currentUser }) {
     }
 
     // Stryker disable all : hard to test for query caching
-
     const deleteMutation = useBackendMutation(
         cellToAxiosParamsDelete,
         { onSuccess: onDeleteSuccess },
@@ -25,7 +23,6 @@ export default function UCSBDatesTable({ dates, currentUser }) {
 
     // Stryker disable next-line all : TODO try to make a good test for this
     const deleteCallback = async (cell) => { deleteMutation.mutate(cell); }
-
 
     const columns = [
         {
@@ -46,18 +43,22 @@ export default function UCSBDatesTable({ dates, currentUser }) {
         }
     ];
 
-    if (hasRole(currentUser, "ROLE_ADMIN")) {
-        columns.push(ButtonColumn("Edit", "primary", editCallback, "UCSBDatesTable"));
-        columns.push(ButtonColumn("Delete", "danger", deleteCallback, "UCSBDatesTable"));
-    } 
+    const columnsIfAdmin = [
+        ...columns,
+        ButtonColumn("Edit", "primary", editCallback, "UCSBDatesTable"),
+        ButtonColumn("Delete", "danger", deleteCallback, "UCSBDatesTable")
+    ]
 
-    // Stryker disable next-line ArrayDeclaration : [columns] is a performance optimization
-    const memoizedColumns = React.useMemo(() => columns, [columns]);
-    const memoizedDates = React.useMemo(() => dates, [dates]);
+    const columnsToDisplay = () => {
+        return hasRole(currentUser, "ROLE_ADMIN") ? columnsIfAdmin : columns;
+    }
+
+    // Stryker disable next-line ArrayDeclaration : [dates] is a performance optimization
+    const memoizedDates = useMemo(() => dates, [dates]);
 
     return <OurTable
         data={memoizedDates}
-        columns={memoizedColumns}
+        columns={columnsToDisplay()}
         testid={"UCSBDatesTable"}
     />;
 };

--- a/frontend/src/main/components/UCSBDates/UCSBDatesTable.js
+++ b/frontend/src/main/components/UCSBDates/UCSBDatesTable.js
@@ -1,4 +1,3 @@
-import { useMemo } from "react";
 import OurTable, { ButtonColumn } from "main/components/OurTable";
 import { useBackendMutation } from "main/utils/useBackend";
 import { cellToAxiosParamsDelete, onDeleteSuccess } from "main/utils/UCSBDateUtils"
@@ -47,18 +46,13 @@ export default function UCSBDatesTable({ dates, currentUser }) {
         ...columns,
         ButtonColumn("Edit", "primary", editCallback, "UCSBDatesTable"),
         ButtonColumn("Delete", "danger", deleteCallback, "UCSBDatesTable")
-    ]
+    ];
 
-    const columnsToDisplay = () => {
-        return hasRole(currentUser, "ROLE_ADMIN") ? columnsIfAdmin : columns;
-    }
-
-    // Stryker disable next-line ArrayDeclaration : [dates] is a performance optimization
-    const memoizedDates = useMemo(() => dates, [dates]);
+    const columnsToDisplay = hasRole(currentUser, "ROLE_ADMIN") ? columnsIfAdmin : columns;
 
     return <OurTable
-        data={memoizedDates}
-        columns={columnsToDisplay()}
+        data={dates}
+        columns={columnsToDisplay}
         testid={"UCSBDatesTable"}
     />;
 };

--- a/frontend/src/main/pages/UCSBDates/UCSBDatesEditPage.js
+++ b/frontend/src/main/pages/UCSBDates/UCSBDatesEditPage.js
@@ -8,7 +8,7 @@ import { toast } from "react-toastify";
 export default function UCSBDatesEditPage() {
   let { id } = useParams();
 
-  const { data: ucsbDate, error: error, status: status } =
+  const { data: ucsbDate } =
     useBackend(
       // Stryker disable next-line all : don't test internal caching of React Query
       [`/api/ucsbdates?id=${id}`],
@@ -20,7 +20,6 @@ export default function UCSBDatesEditPage() {
         }
       }
     );
-
 
   const objectToAxiosPutParams = (ucsbDate) => ({
     url: "/api/ucsbdates",

--- a/frontend/src/main/utils/UCSBDateUtils.js
+++ b/frontend/src/main/utils/UCSBDateUtils.js
@@ -1,5 +1,4 @@
 import { toast } from "react-toastify";
-import { useNavigate } from 'react-router-dom'
 
 export function onDeleteSuccess(message) {
     console.log(message);

--- a/frontend/src/tests/components/Students/StudentsTable.test.js
+++ b/frontend/src/tests/components/Students/StudentsTable.test.js
@@ -1,61 +1,28 @@
-import { fireEvent, render, waitFor } from "@testing-library/react";
+import { render } from "@testing-library/react";
 import { studentFixtures } from "fixtures/studentFixtures";
 import StudentsTable from "main/components/Students/StudentsTable"
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
-import { currentUserFixtures } from "fixtures/currentUserFixtures";
-
 
 describe("StudentsTable tests", () => {
   const queryClient = new QueryClient();
 
-  test("renders without crashing for empty table with user not logged in", () => {
-    const currentUser = null;
-
+  test("renders without crashing for empty table", () => {
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <StudentsTable students={[]} currentUser={currentUser} />
+          <StudentsTable students={[]} />
         </MemoryRouter>
       </QueryClientProvider>
 
     );
   });
 
-  test("renders without crashing for empty table for ordinary user", () => {
-    const currentUser = currentUserFixtures.userOnly;
-
-    render(
-      <QueryClientProvider client={queryClient}>
-        <MemoryRouter>
-          <StudentsTable students={[]} currentUser={currentUser} />
-        </MemoryRouter>
-      </QueryClientProvider>
-
-    );
-  });
-
-  test("renders without crashing for empty table for admin", () => {
-    const currentUser = currentUserFixtures.adminUser;
-
-    render(
-      <QueryClientProvider client={queryClient}>
-        <MemoryRouter>
-          <StudentsTable students={[]} currentUser={currentUser} />
-        </MemoryRouter>
-      </QueryClientProvider>
-
-    );
-  });
-
-  test("Has the expected colum headers and content for adminUser", () => {
-
-    const currentUser = currentUserFixtures.adminUser;
-
+  test("Has the expected colum headers and content", () => {
     const { getByText, getByTestId } = render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <StudentsTable students={studentFixtures.twoStudents} currentUser={currentUser} />
+          <StudentsTable students={studentFixtures.twoStudents} />
         </MemoryRouter>
       </QueryClientProvider>
 

--- a/frontend/src/tests/components/UCSBDates/UCSBDatesTable.test.js
+++ b/frontend/src/tests/components/UCSBDates/UCSBDatesTable.test.js
@@ -99,7 +99,7 @@ describe("UserTable tests", () => {
 
     const currentUser = currentUserFixtures.adminUser;
 
-    const { getByText, getByTestId } = render(
+    const { getByTestId } = render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
           <UCSBDatesTable dates={ucsbDatesFixtures.threeDates} currentUser={currentUser} />

--- a/frontend/src/tests/pages/UCSBDates/UCSBDatesEditPage.test.js
+++ b/frontend/src/tests/pages/UCSBDates/UCSBDatesEditPage.test.js
@@ -1,4 +1,4 @@
-import { fireEvent, queryByTestId, render, waitFor } from "@testing-library/react";
+import { fireEvent, render, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 import UCSBDatesEditPage from "main/pages/UCSBDates/UCSBDatesEditPage";
@@ -110,7 +110,6 @@ describe("UCSBDatesEditPage tests", () => {
             const quarterYYYYQField = getByTestId("UCSBDateForm-quarterYYYYQ");
             const nameField = getByTestId("UCSBDateForm-name");
             const localDateTimeField = getByTestId("UCSBDateForm-localDateTime");
-            const submitButton = getByTestId("UCSBDateForm-submit");
 
             expect(idField).toHaveValue("17");
             expect(quarterYYYYQField).toHaveValue("20221");

--- a/frontend/src/tests/utils/UCSBDateUtils.test.js
+++ b/frontend/src/tests/utils/UCSBDateUtils.test.js
@@ -1,4 +1,4 @@
-import { onDeleteSuccess, cellToAxiosParamsDelete, editCallback } from "main/utils/UCSBDateUtils";
+import { onDeleteSuccess, cellToAxiosParamsDelete } from "main/utils/UCSBDateUtils";
 import mockConsole from "jest-mock-console";
 
 const mockToast = jest.fn();


### PR DESCRIPTION
This PR re-introduces ESLint, which was removed in ucsb-cs156-w22/demo-spring-react-example-v2#75 as a temporary fix to build problems on Heroku. The changes in that PR are partially reverted, and all linting issues are fixed.

I'm still not entirely sure why it broke in the first place, but everything seems to work now, so I'm going to assume all is well. Perhaps it's because of the Node version upgrades.

Note that this PR includes changes from #9, where the aforementioned Node upgrade / version consistency changes were implemented. Please merge that PR before merging this one.

Closes #2 