### PR TITLE
AL/AS - Fix page title for prod Storybook index page

### DIFF
--- a/frontend/docs-index/_layouts/default.html
+++ b/frontend/docs-index/_layouts/default.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/{{site.repo_name}}/css/style.css">
   </head>
   <body>
-    <h1>{{site.repo_name}}-qa-docs</h1>
+    <h1>{{site.repo_name}}-docs</h1>
     <section>
       {{ content }}
     </section>


### PR DESCRIPTION
Closes ucsb-cs156-s22/STARTER-team03-docs#1

@aaron-sgy noticed that the title for the index page for Storybook docs (non-QA) incorrectly shows QA, which has been causing confusion among some students. This PR removes that.