### PR TITLE
AL - Fix -docs and -docs-qa repo creation workflow

### DIFF
--- a/.github/workflows/00-publish-docs-to-github-pages-setup.yml
+++ b/.github/workflows/00-publish-docs-to-github-pages-setup.yml
@@ -1,64 +1,60 @@
-
 name: "00-publish-docs-to-github-pages-setup: set up -docs and -docs-qa repos (run once, manually)"
 on: 
   workflow_dispatch:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.DOCS_TOKEN }}
+      TEMPLATE: "https://github.com/ucsb-cs156/TEMPLATE-docs"
+      OWNER: ${{ github.repository_owner }}
+      REPOSITORY: ${{ github.event.repository.name }}
+      OWNER_PLUS_REPOSITORY: ${{ github.repository }}
     steps:
       - name: "Create -docs repo"
         working-directory: .
         continue-on-error: true
         run: |
           SUFFIX="-docs"
-          DESC="Documentation for ${OWNER_PLUS_REPOSITORY}"
-          TEMPLATE="https://github.com/ucsb-cs156-w22/TEMPLATE-docs"
-          OWNER_PLUS_REPOSITORY=${{github.repository}}
-          OWNER=${{ github.repository_owner }}
-          REPOSITORY=${OWNER_PLUS_REPOSITORY/$OWNER\//}
-          HOMEPAGE="https://${OWNER}.github.io/${REPOSITORY}${SUFFIX}"
-          NEW_REPO=${OWNER_PLUS_REPOSITORY}${SUFFIX}        
-          gh repo create ${NEW_REPO} --public --description "${DESC}" --template ${TEMPLATE}
-        env:
-          GITHUB_TOKEN: ${{ secrets.DOCS_TOKEN }}
-      - name: "Set homepage in -docs repo"
+          NEW_REPO=${OWNER_PLUS_REPOSITORY}${SUFFIX}
+          gh repo create ${NEW_REPO} --public --template ${TEMPLATE}
+      - name: "Set description and homepage in -docs repo"
+        # This separate step is necessary because of a limitation where --homepage and --template cannot be used together!
         working-directory: .
         continue-on-error: true
         run: |
           SUFFIX="-docs"
-          OWNER=${{ github.repository_owner }}
-          REPOSITORY=${OWNER_PLUS_REPOSITORY/$OWNER\//}
+          DESC="Production documentation for ${OWNER_PLUS_REPOSITORY}"
           HOMEPAGE="https://${OWNER}.github.io/${REPOSITORY}${SUFFIX}"
           NEW_REPO=${OWNER_PLUS_REPOSITORY}${SUFFIX}
-          gh repo edit ${NEW_REPO} --homepage ${HOMEPAGE}
-        env:
-          GITHUB_TOKEN: ${{ secrets.DOCS_TOKEN }}
+          gh repo edit ${NEW_REPO} --description "${DESC}" --homepage ${HOMEPAGE}
+      - name: "Enable GitHub Pages in -docs repo"
+        working-directory: .
+        continue-on-error: true
+        run: |
+          SUFFIX="-docs"
+          jq -n '{"build_type": "legacy", "source": {"branch": "main", "path": "/docs"}}' | gh api repos/${OWNER_PLUS_REPOSITORY}${SUFFIX}/pages --input -
       - name: "Create -docs-qa repo"
         working-directory: .
         continue-on-error: true
         run: |
           SUFFIX="-docs-qa"
-          DESC="Documentation QA site for ${OWNER_PLUS_REPOSITORY}"
-          TEMPLATE="https://github.com/ucsb-cs156-w22/TEMPLATE-docs"
-          OWNER_PLUS_REPOSITORY=${{github.repository}}
-          OWNER=${{ github.repository_owner }}
-          REPOSITORY=${OWNER_PLUS_REPOSITORY/$OWNER\//}
-          HOMEPAGE="https://${OWNER}.github.io/${REPOSITORY}${SUFFIX}"
-          NEW_REPO=${OWNER_PLUS_REPOSITORY}${SUFFIX}        
-          gh repo create ${NEW_REPO} --public --description "${DESC}" --template ${TEMPLATE}
-        env:
-          GITHUB_TOKEN: ${{ secrets.DOCS_TOKEN }}
-      - name: "Set homepage in -docs-qa repo"
+          NEW_REPO=${OWNER_PLUS_REPOSITORY}${SUFFIX}
+          gh repo create ${NEW_REPO} --public --template ${TEMPLATE}
+      - name: "Set description and homepage in -docs-qa repo"
+        # This separate step is necessary because of a limitation where --homepage and --template cannot be used together!
         working-directory: .
         continue-on-error: true
         run: |
           SUFFIX="-docs-qa"
-          OWNER_PLUS_REPOSITORY=${{github.repository}}
-          OWNER=${{ github.repository_owner }}
-          REPOSITORY=${OWNER_PLUS_REPOSITORY/$OWNER\//}
+          DESC="QA documentation for ${OWNER_PLUS_REPOSITORY}"
           HOMEPAGE="https://${OWNER}.github.io/${REPOSITORY}${SUFFIX}"
           NEW_REPO=${OWNER_PLUS_REPOSITORY}${SUFFIX}
-          gh repo edit ${NEW_REPO} --homepage ${HOMEPAGE}
-        env:
-          GITHUB_TOKEN: ${{ secrets.DOCS_TOKEN }}
+          gh repo edit ${NEW_REPO} --description "${DESC}" --homepage ${HOMEPAGE}
+      - name: "Enable GitHub Pages in -docs-qa repo"
+        working-directory: .
+        continue-on-error: true
+        run: |
+          SUFFIX="-docs-qa"
+          jq -n '{"build_type": "legacy", "source": {"branch": "main", "path": "/docs"}}' | gh api repos/${OWNER_PLUS_REPOSITORY}${SUFFIX}/pages --input -
    


### PR DESCRIPTION
# Overview

This PR fixes the -docs and -docs-qa repo creation workflow used to initially setup Storybook builds and deploys and automatically enables GitHub Pages on those repos from the `/docs` branch so users will not have to manually enable it themselves.

Note that this workflow is still dependent on a `DOCS_TOKEN` secret being initialized with a GitHub Personal Access Token of a user who has administrative privileges to the project repository and repo create privileges in the project's organization. (Though it might be possible to omit this as well if we can make the built-in GitHub Actions token more permissive).

Specifically:
* The template repo was migrated to the `ucsb-cs156` organization and its URL was changed
* Values for `REPOSITORY` and `OWNER_PLUS_REPOSITORY` have been fixed and factored out into the overall job environment
* Docs repo description now indicates whether it is a production or QA deployment
* Using the GitHub API, GitHub Pages is automatically enabled on the newly-created repositories through this workflow
  * This includes setting the deploys to be from the `main` branch and from the `/docs` folder
